### PR TITLE
Node option to avoid heap out of memory

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -317,6 +317,9 @@ services:
         - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
         # DO NOT TURN ON unless you have EXPLICIT PERMISSION from Onyx.
         - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
+        # Increases the max memory for the node process to avoid:
+        # "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory"
+        - NODE_OPTIONS=--max-old-space-size=4096
     depends_on:
       - api_server
     restart: unless-stopped


### PR DESCRIPTION
Increase the memory in node when building the image to avoid:
```
"FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory"
```