### PR TITLE
Adds endpoint to the onyx API for using the search tool

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -93,6 +93,7 @@ from onyx.server.middleware.rate_limiting import close_auth_limiter
 from onyx.server.middleware.rate_limiting import get_auth_rate_limiters
 from onyx.server.middleware.rate_limiting import setup_auth_limiter
 from onyx.server.onyx_api.ingestion import router as onyx_api_router
+from onyx.server.onyx_api.tools import router as api_tools_router
 from onyx.server.openai_assistants_api.full_openai_assistants_api import (
     get_full_openai_assistants_api_router,
 )
@@ -354,6 +355,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, admin_tool_router)
     include_router_with_global_prefix_prepended(application, state_router)
     include_router_with_global_prefix_prepended(application, onyx_api_router)
+    include_router_with_global_prefix_prepended(application, api_tools_router)
     include_router_with_global_prefix_prepended(application, gpts_router)
     include_router_with_global_prefix_prepended(application, settings_router)
     include_router_with_global_prefix_prepended(application, settings_admin_router)

--- a/backend/onyx/server/onyx_api/tools.py
+++ b/backend/onyx/server/onyx_api/tools.py
@@ -1,0 +1,99 @@
+from fastapi import APIRouter
+from fastapi import Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import api_key_dep
+from onyx.chat.models import AnswerStyleConfig
+from onyx.chat.models import CitationConfig
+from onyx.chat.models import DocumentPruningConfig
+from onyx.chat.models import PromptConfig
+from onyx.context.search.enums import LLMEvaluationType
+from onyx.context.search.models import RetrievalDetails
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.models import User
+from onyx.db.persona import get_persona_by_id
+from onyx.prompts.prompt_utils import build_complete_context_str
+from onyx.llm.factory import get_default_llms
+from onyx.tools.tool_implementations.search.search_tool import SearchTool
+from onyx.tools.tool_implementations.search_like_tool_utils import (
+    FINAL_CONTEXT_DOCUMENTS_ID,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+router = APIRouter(prefix="/onyx-tools")
+
+
+class SearchToolRequest(BaseModel):
+    query: str
+
+
+class SearchToolResponse(BaseModel):
+    results: str
+
+
+@router.post("/search-tool")
+def search_tool_endpoint(
+    request: SearchToolRequest,
+    _: User | None = Depends(api_key_dep),
+    db_session: Session = Depends(get_session),
+) -> SearchToolResponse:
+    """
+    Endpoint that exposes the SearchTool.run() method for MCP server integration.
+
+    This endpoint initializes a SearchTool instance and runs a search query,
+    returning the final context documents as structured results.
+    """
+    logger.info(f"Received SearchTool request with query: {request.query}")
+
+    # Get default LLMs
+    primary_llm, fast_llm = get_default_llms()
+
+    # Get default persona (id=0)
+    persona = get_persona_by_id(0, None, db_session)
+
+    # Set up configurations
+    retrieval_options = RetrievalDetails()
+    prompt_config = PromptConfig.from_model(persona.prompts[0])
+    pruning_config = DocumentPruningConfig()
+    answer_style_config = AnswerStyleConfig(citation_config=CitationConfig())
+    evaluation_type = LLMEvaluationType.SKIP
+
+    # Create SearchTool instance
+    search_tool = SearchTool(
+        db_session=db_session,
+        user=None,  # No specific user
+        persona=persona,
+        retrieval_options=retrieval_options,
+        prompt_config=prompt_config,
+        llm=primary_llm,
+        fast_llm=fast_llm,
+        document_pruning_config=pruning_config,
+        answer_style_config=answer_style_config,
+        evaluation_type=evaluation_type,
+    )
+
+    # Run the search
+    results = []
+    try:
+        for response in search_tool.run(query=request.query):
+            results.append(response)
+
+        # Extract the final context documents
+        final_docs_response = next(
+            (response for response in results if response.id == FINAL_CONTEXT_DOCUMENTS_ID),
+            None
+        )
+
+        if final_docs_response:
+            final_docs = build_complete_context_str(final_docs_response.response)
+            return SearchToolResponse(results=final_docs)
+        else:
+            logger.warning("No final context documents found in search results")
+            return SearchToolResponse(results="")
+
+    except Exception as e:
+        logger.error(f"Error running SearchTool: {str(e)}", exc_info=True)
+        return SearchToolResponse(results="")

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     command: >
       /bin/sh -c "alembic upgrade head &&
       echo \"Starting Onyx Api Server\" &&
-      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+      uvicorn onyx.main:app --host 0.0.0.0 --port 8080 --reload"
     depends_on:
       - relational_db
       - index
@@ -151,6 +151,7 @@ services:
         max-file: "6"
     # optional, only for debugging purposes
     volumes:
+      - ../../backend/onyx:/app/onyx:rw
       - api_server_logs:/var/log
 
   background:


### PR DESCRIPTION
## Description

Usage:
```bash
curl -X POST "http://localhost:8080/onyx-tools/search-tool" \
    -H "Content-Type: application/json" \
    -d '{"query": "key projects stacklok"}' | jq
```

## How Has This Been Tested?

Using local `docker compose` and `curl`

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
