### PR TITLE
Remove unused DocumentResult class

### DIFF
--- a/backend/onyx/server/onyx_api/tools.py
+++ b/backend/onyx/server/onyx_api/tools.py
@@ -30,17 +30,6 @@ class SearchToolRequest(BaseModel):
     query: str
 
 
-class DocumentResult(BaseModel):
-    document_id: str
-    title: str
-    content: str
-    source_type: str
-    link: str | None
-    source_links: dict[int, str] | None
-    metadata: dict[str, str | list[str]]
-    updated_at: str | None
-
-
 class SearchToolResponse(BaseModel):
     results: str
 


### PR DESCRIPTION
## Description

Removes an unused class in the code
Closes: https://github.com/stacklok/research/issues/205

## How Has This Been Tested?

Ran the command
```bash
curl -X POST "http://localhost:8080/onyx-tools/search-tool" \
    -H "Content-Type: application/json" \
    -d '{"query": "key projects stacklok"}' | jq;
```

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
