### PR TITLE
Enhance search API with filtering and structured response

### DIFF
--- a/backend/onyx/server/onyx_api/tools.py
+++ b/backend/onyx/server/onyx_api/tools.py
@@ -1,20 +1,23 @@
+from datetime import datetime
 from fastapi import APIRouter
 from fastapi import Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import api_key_dep
-from onyx.chat.models import AnswerStyleConfig
+from onyx.chat.models import AnswerStyleConfig, LlmDoc
 from onyx.chat.models import CitationConfig
 from onyx.chat.models import DocumentPruningConfig
 from onyx.chat.models import PromptConfig
+from onyx.configs.constants import DocumentSource
 from onyx.context.search.enums import LLMEvaluationType
 from onyx.context.search.models import RetrievalDetails
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id
-from onyx.prompts.prompt_utils import build_complete_context_str
+from onyx.prompts.prompt_utils import clean_up_source
 from onyx.llm.factory import get_default_llms
+from onyx.tools.models import SearchToolOverrideKwargs, ToolResponse
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.search_like_tool_utils import (
     FINAL_CONTEXT_DOCUMENTS_ID,
@@ -28,10 +31,16 @@ router = APIRouter(prefix="/onyx-tools")
 
 class SearchToolRequest(BaseModel):
     query: str
+    time_cutoff: datetime | None = None
+    document_sources: list[DocumentSource] | None = None
 
 
-class SearchToolResponse(BaseModel):
-    results: str
+class FoundDocSearchTool(BaseModel):
+    title: str
+    source_type: str
+    content: str
+    updated_at: datetime | None = None
+    link: str | None = None
 
 
 @router.post("/search-tool")
@@ -39,14 +48,14 @@ def search_tool_endpoint(
     request: SearchToolRequest,
     _: User | None = Depends(api_key_dep),
     db_session: Session = Depends(get_session),
-) -> SearchToolResponse:
+) -> list[FoundDocSearchTool]:
     """
     Endpoint that exposes the SearchTool.run() method for MCP server integration.
 
     This endpoint initializes a SearchTool instance and runs a search query,
     returning the final context documents as structured results.
     """
-    logger.info(f"Received SearchTool request with query: {request.query}")
+    logger.info(f"Received SearchTool request with query: {request=}")
 
     # Get default LLMs
     primary_llm, fast_llm = get_default_llms()
@@ -75,30 +84,40 @@ def search_tool_endpoint(
         evaluation_type=evaluation_type,
     )
 
+    # Prepare override kwargs for filtering
+    override_kwargs = None
+    if request.time_cutoff or request.document_sources:
+        override_kwargs = SearchToolOverrideKwargs(
+            time_cutoff=request.time_cutoff,
+            document_sources=request.document_sources
+        )
+
     # Run the search
     results = []
     try:
-        for response in search_tool.run(query=request.query):
+        for response in search_tool.run(override_kwargs=override_kwargs, query=request.query):
             results.append(response)
 
         # Extract the final context documents
-        final_docs_response = next((response for response in results if response.id == FINAL_CONTEXT_DOCUMENTS_ID), None)
+        final_docs_response: ToolResponse | None = next((response for response in results if response.id == FINAL_CONTEXT_DOCUMENTS_ID), None)
 
         if final_docs_response:
             # Extract document information for structured response
-            for doc in final_docs_response.response:
-                if doc.metadata:
-                    doc.metadata["link"] = doc.link
-                else:
-                    doc.metadata = {"link": doc.link}
-
-            final_docs_str = build_complete_context_str(final_docs_response.response)
-
-            return SearchToolResponse(results=final_docs_str)
+            llm_docs: list[LlmDoc] = final_docs_response.response
+            found_docs = [
+                FoundDocSearchTool(
+                        title=doc.semantic_identifier,
+                        source_type=clean_up_source(doc.source_type),
+                        content=doc.content.strip(),
+                        updated_at=doc.updated_at,
+                        link=doc.link
+                    ) for doc in llm_docs
+            ]
+            return found_docs
         else:
             logger.warning("No final context documents found in search results")
-            return SearchToolResponse(results="")
+            return []
 
     except Exception as e:
         logger.error(f"Error running SearchTool: {str(e)}", exc_info=True)
-        return SearchToolResponse(results="")
+        return []


### PR DESCRIPTION
Related to: https://github.com/StacklokLabs/research/issues/19

## Description

- Add time_cutoff parameter to filter results by date
- Add document_sources parameter to filter by source types
- Replace string response with structured FoundDocSearchTool objects
- Update SearchToolRequest model with new optional parameters
- Improve type hints using modern Python syntax (list[] vs List[])

**Note**: The deployment to K8s needs to be in coordination with: https://github.com/StacklokLabs/knowledge-mcp-server/pull/18

🤖 Generated with [Claude Code](https://claude.ai/code)

## How Has This Been Tested?

```bash
curl -X POST "http://localhost:8080/onyx-tools/search-tool" \
    -H "Content-Type: application/json" \
    -d '{
        "query": "key projects stacklok"
    }' | jq
```

```bash
curl -X POST "http://localhost:8080/onyx-tools/search-tool" \
    -H "Content-Type: application/json" \
    -d '{
        "query": "key projects stacklok",
        "time_cutoff": "2024-01-01T00:00:00Z"
    }' | jq
```

```bash
curl -X POST "http://localhost:8080/onyx-tools/search-tool" \
    -H "Content-Type: application/json" \
    -d '{
        "query": "key projects stacklok",
        "time_cutoff": "2024-01-01T00:00:00Z",
        "document_sources": ["google_drive"]
    }' | jq
```

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
