### PR TITLE
Enables basic auth in Onyx

### DIFF
--- a/backend/onyx/server/onyx_api/tools.py
+++ b/backend/onyx/server/onyx_api/tools.py
@@ -46,7 +46,7 @@ class FoundDocSearchTool(BaseModel):
 @router.post("/search-tool")
 def search_tool_endpoint(
     request: SearchToolRequest,
-    _: User | None = Depends(api_key_dep),
+    search_user: User | None = Depends(api_key_dep),
     db_session: Session = Depends(get_session),
 ) -> list[FoundDocSearchTool]:
     """
@@ -73,7 +73,7 @@ def search_tool_endpoint(
     # Create SearchTool instance
     search_tool = SearchTool(
         db_session=db_session,
-        user=None,  # No specific user
+        user=search_user,
         persona=persona,
         retrieval_options=retrieval_options,
         prompt_config=prompt_config,

--- a/deployment/helm/charts/onyx/stacklok_values.yaml
+++ b/deployment/helm/charts/onyx/stacklok_values.yaml
@@ -662,7 +662,7 @@ auth:
 
 configMap:
   # Change this for production uses unless Onyx is only accessible behind VPN
-  AUTH_TYPE: "disabled"
+  AUTH_TYPE: "basic"
   # 1 Day Default
   SESSION_EXPIRE_TIME_SECONDS: "86400"
   # Can be something like onyx.app, as an extra double-check


### PR DESCRIPTION
Closes: https://github.com/StacklokLabs/research/issues/20

## Description

Before we we're not authenticating in Onyx. Now the requests should be authenticated for them to be successful

## How Has This Been Tested?

curl command
```bash
curl -X POST "http://localhost:8080/onyx-tools/search-tool" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $ONYX_API_KEY" \
    -d '{
        "query": "key projects stacklok",
        "time_cutoff": "2024-01-01T00:00:00Z",
        "document_sources": ["google_drive"]
    }' | jq
```

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
