### PR TITLE
Added the semantic_identifier as searchable parameter in Vespa

### DIFF
--- a/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja
+++ b/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja
@@ -25,7 +25,8 @@ schema {{ schema_name }} {
         }
         # Displayed in the UI as the main identifier for the doc
         field semantic_identifier type string {
-            indexing: summary | attribute
+            indexing: summary | index | attribute
+            index: enable-bm25
         }
         # Must have an additional field for whether to skip title embeddings
         # This information cannot be extracted from either the title field nor title embedding

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -68,6 +68,7 @@ from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.document_index.vespa_constants import DOCUMENT_SETS
 from onyx.document_index.vespa_constants import HIDDEN
 from onyx.document_index.vespa_constants import NUM_THREADS
+from onyx.document_index.vespa_constants import SEMANTIC_IDENTIFIER
 from onyx.document_index.vespa_constants import USER_FILE
 from onyx.document_index.vespa_constants import USER_FOLDER
 from onyx.document_index.vespa_constants import VESPA_APPLICATION_ENDPOINT
@@ -955,7 +956,8 @@ class VespaIndex(DocumentIndex):
             + f"(({{targetHits: {target_hits}}}nearestNeighbor(embeddings, query_embedding)) "
             + f"or ({{targetHits: {target_hits}}}nearestNeighbor(title_embedding, query_embedding)) "
             + 'or ({grammar: "weakAnd"}userInput(@query)) '
-            + f'or ({{defaultIndex: "{CONTENT_SUMMARY}"}}userInput(@query)))'
+            + f'or ({{defaultIndex: "{CONTENT_SUMMARY}"}}userInput(@query)) '
+            + f'or ({{defaultIndex: "{SEMANTIC_IDENTIFIER}"}}userInput(@query)))'
         )
 
         final_query = " ".join(final_keywords) if final_keywords else query
@@ -1003,7 +1005,8 @@ class VespaIndex(DocumentIndex):
             # `({defaultIndex: "content_summary"}userInput(@query))` section is
             # needed for highlighting while the N-gram highlighting is broken /
             # not working as desired
-            + f'or ({{defaultIndex: "{CONTENT_SUMMARY}"}}userInput(@query)))'
+            + f'or ({{defaultIndex: "{CONTENT_SUMMARY}"}}userInput(@query)) '
+            + f'or ({{defaultIndex: "{SEMANTIC_IDENTIFIER}"}}userInput(@query)))'
         )
 
         params: dict[str, str | int] = {


### PR DESCRIPTION
Closes: https://github.com/StacklokLabs/research/issues/28

## Description

1. Updated Vespa Schema Template (backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja:27-30)
  - Modified the semantic_identifier field to enable keyword search indexing
  - Added index | attribute and index: enable-bm25 to make it searchable
2. Updated Query Construction (backend/onyx/document_index/vespa/index.py:960, 1009)
  - Added SEMANTIC_IDENTIFIER import
  - Modified both hybrid_retrieval and admin_retrieval methods to include semantic_identifier in their YQL queries
  - Added or ({defaultIndex: "semantic_identifier"}userInput(@query)) clause

## How Has This Been Tested?

## Re-indexing Methods (Gotten with AI but seem to be correct)

### Method 1: API Endpoint
                                                                                                                                                                     
Use the /admin/connector/run-once API endpoint to trigger re-indexing for specific connectors:
                                                                                             
Endpoint: POST /manage/admin/connector/run-once                                                                                                                                            

Request Body:                                                                                                                                                                              
{
  "connector_id": <connector_id>,
  "credential_ids": [<credential_id1>, <credential_id2>],  // optional, if not provided, uses all credentials
  "from_beginning": true  // This triggers a REINDEX instead of UPDATE
}
                                                                                                                                                                                          
Key Points:
- Setting from_beginning: true triggers a full REINDEX (IndexingMode.REINDEX)
- Setting from_beginning: false triggers an incremental UPDATE (IndexingMode.UPDATE)
- The API sets an indexing_trigger field on the connector-credential pairs
- A background Celery task picks up these triggers and performs the actual re-indexing

Local example:
```bash
% curl -X POST "http://localhost:8080/manage/admin/connector/run-once" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $ONYX_API_KEY" \
    -d '{
        "connector_id": 2,
        "from_beginning": true
    }'
```
The `$ONYX_API_KEY` needs to be created from Onyx Admin UI and the scope set to Admin.

### Method 2: Direct Database Update

If API access is not available, you can directly update the database:
1. Set the indexing_trigger field to 'REINDEX' for connector-credential pairs:
```sql
UPDATE connector_credential_pair
SET indexing_trigger = 'REINDEX'
WHERE connector_id = <your_connector_id>;
```
                                                                                                                                                                                        
2. The background task (CHECK_FOR_INDEXING) will pick up this trigger and start re-indexing.

### Monitor re-indexing status

Check indexing status:
```bash
curl -X GET "http://localhost:8080/manage/admin/connector/indexing-status" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $ONYX_API_KEY"
```

Check indexing attemps:
```bash
curl -X GET "http://localhost:8080//manage/admin/cc-pair/{cc_pair_id}/index-attempts" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $ONYX_API_KEY"
```

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
