### PR TITLE
Return metadata in SearchTool request

### DIFF
--- a/backend/onyx/server/onyx_api/tools.py
+++ b/backend/onyx/server/onyx_api/tools.py
@@ -1,8 +1,7 @@
-from dataclasses import Field
 from datetime import datetime
 from fastapi import APIRouter
 from fastapi import Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import api_key_dep
@@ -52,6 +51,7 @@ class FoundDocSearchTool(BaseModel):
     content: str
     updated_at: datetime | None = None
     link: str | None = None
+    metadata: dict[str, str | list[str]] | None = None
 
 
 @router.post("/search-tool")
@@ -121,7 +121,8 @@ def search_tool_endpoint(
                         source_type=clean_up_source(doc.source_type),
                         content=doc.content.strip(),
                         updated_at=doc.updated_at,
-                        link=doc.link
+                        link=doc.link,
+                        metadata=doc.metadata
                     ) for doc in llm_docs
             ]
             return found_docs


### PR DESCRIPTION
## Description

- Document `metadata` is now returned in SearchTool
- Fixed import error

This needs to go hand-by-hand: https://github.com/StacklokLabs/knowledge-mcp-server/pull/35

## How Has This Been Tested?

```bash
curl -X POST "http://localhost:8080/onyx-tools/search-tool" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $ONYX_API_KEY" \
    -d '{
        "query": "key projects stacklok",
        "time_cutoff": "2024-01-01T00:00:00Z",
        "document_sources": ["google_drive"],
        "limit": 5
    }' | jq
```

Response:
```json
[
  {
    "title": "Stacklok DNS Management",
    "source_type": "Google Drive",
    "content": "Stacklok DNS Management\nCONFIDENTIAL - INTERNAL ONLY\n\n\nStatus: Draft\nLast Updated: Apr 9, 2025\nAuthor(s): Chris Burns\n\n\nExecutive Overview\nThis document aims to provide a holistic view of Stackloks DNS infrastructure. There are a mixture of platforms, procedures and processes that encompass the wider DNS infrastructure at Stacklok, and this document aims to provide detailed information on the what, why and how.\n\n\nInfrastructure\nOur DNS and email infrastructure employs a best practice approach to protect against unauthorized use of our domain and potential email-based attacks. This strategy centers around three core technologies: CAA (Certificate Authority Authorization), DKIM (DomainKeys Identified Mail), and DMARC (Domain-based Message Authentication, Reporting, and Conformance).\n\n\nDNS Security\n\n\nCAA (Certificate Authority Authorization)\n* Purpose: CAA functions as a domain-level access control mechanism. It explicitly defines which Certificate Authorities (CAs) are permitted to issue digital certificates for our domain.\n* Implementation: A CAA record is published within our Domain Name System (DNS). This record lists the approved CAs. When a CA receives a certificate issuance request for our domain, it is obligated to query the CAA record. If the CA is not listed, it must reject the request.\n* Benefits: CAA prevents unauthorized entities from obtaining fraudulent certificates for our domain. This thwarts attempts to spoof our domain in phishing attacks and other malicious activities.\n\n\nWhat We Do?\nWe currently have Route 53 CAA records that provide a domain level access control mechanism that permits what can issue digital certificates for our domain.\n\n\nRoute 53 CAA Record\n\tZone\n\tRecords\n\tComments\n\t\n\tstacklok.com\n\t* amazon.com\n* pki.goog\n* letsencrypt.org\n* mailto:infra@stacklok.com\n\tWe whitelist what domains can issue certificates for our domain.\nSPF\n* Purpose: An SPF (Sender Policy Framework) record is a type of DNS TXT record that specifies the IP addresses of mail servers authorized to send emails on behalf of a domain, helping to prevent email spoofing and improve email deliverability.\n* Implementation: In AWS Route 53, we have DNS TXT records that include addresses that we allow to send email on behalf of Stacklok. This includes Google.com and HubSpot, and nothing else is allowed (~all)\n\n\nAWS Route 53 SPF TXT Records\n\n\nRoute 53 TXT Record\n\tRecords\n\tRoot Domain\n* Applied to the root domain stacklok.com\n* Is an empty string in R53\n\tSPF allow list for sending emails on behalf of Stacklok.com:\n* Google\n* HubSpot\n\n\nGoogle Site Verification token that proves to Google Search Console that we own the site.\n\n\nHubSpot is used by marketing department so we authorize HubSpot to send emails on behalf of Stacklok, and the TXT SPF record is giving that permission \n\tgh-mail\n\tAllow list for sending emails on behalf of gh-mail.stacklok.com\n* GreenHouse (via MailGun)\n\t\n\nIf the sites are not included in the above table, then they are not authorized to send emails on behalf of the Stacklok.com domain.\n* Benefits: Spoofed emails (e.g. phishing attacks and other fraud) pretending to come from @stacklok.com addresses should be dropped by the receiving email system, when combined with DMARC and DKIM\n\n\n\n\nDKIM (DomainKeys Identified Mail)\n* Purpose: DKIM provides a method for digitally signing outgoing email messages. This signature, linked to our domain, allows recipients to verify the message's authenticity and integrity.\n* Implementation: A private key, known only to our mail server, is used to generate a unique cryptographic signature for each outgoing email. This signature is added to the email header. The recipient's mail server uses a public key, published in our DNS DKIM record, to validate the signature.\n   1. Because DKIM publishes public keys, we usually need to get the record value from the service provider.  This may be a CNAME or a literal record.\n* Benefits: DKIM ensures that email content has not been altered during transit and confirms that the message originated from our authorized mail server.\nWhat We Do?\n\n\nRoute 53 TXT Record\n\tZone\n\tComments\n\tgoogle._domainkey\n\tstacklok.com\n\tIs the domain key for Google to provide integrity for emails sent from on behalf of stacklok.com\n\tk1._domainkey.gh-mail\n\tstacklok.com\n\tIs the domain key for Greenhouse to provide integrity for emails sent from stacklok.com\n\t\n\n\n\nDMARC (Domain-based Message Authentication, Reporting, and Conformance)\n* Purpose: DMARC acts as a policy framework that unifies CAA and DKIM. It dictates how recipient mail servers should handle incoming emails that fail authentication checks (DKIM or SPF).\n* Implementation: A DMARC policy record is published in our DNS. This record specifies actions to be taken on messages that fail authentication (e.g., reject, quarantine, or none). Additionally, DMARC provides the ability to receive reports on email authentication outcomes.\n* Benefits: DMARC strengthens email security by enforcing consistent policies for unauthenticated messages. The reporting feature allows for monitoring and troubleshooting of email authentication issues.\nA DMARC policy determines what happens to an email after it is checked against SPF and DKIM records. An email either passes or fails SPF and DKIM. The DMARC policy determines if failure results in the email being marked as spam, getting blocked, or being delivered to its intended recipient. (Email servers may still mark emails as spam if there is no DMARC record, but DMARC provides clearer instructions on when to do so.)\nDMARC Reports\n\n\nDMARC generates aggregate reports (as XML attachments) that are sent from recipient mail servers to the address specified in the DMARC record. These reports contain data on email authentication results, including:\n* Source IP addresses of sending servers\n* Authentication outcomes (pass/fail) for DKIM and SPF\n* Number of messages affected\nAnalysis of these reports provides insights into potential misconfigurations or unauthorized use of our domain in email communications. This information aids in proactively addressing vulnerabilities and maintaining the integrity of our email ecosystem.\n\n\nWhile its possible to download the XML reports and read them manually, they are much easier to handle when aggregated by custom tools.  We use DMARC Report in the free (1-user) tier for this.  The email address registered is dmarcreports@stacklok.com (Google Group), which is also the mailing list that we get direct reports from.  The login for DMARC Report is in 1Password, in the infra shared folder\n\n\n\n\n\n\nRoute 53 TXT Record\n\tZone\n\tComments\n\t_dmarc\n\tcodegate.ai\n\tIs the TXT record that details the DMARC policy.\n\n\nWhat is it doing for codegate.ai ? is it a policy for emails sent from the codegate.ai domain?\n\t_dmarc\n\tstacklok.com\n\tIs the TXT record that details the DMARC policy for the stacklok.com domain.\n\t\n\n\n\n\n\n\n\n\n\nAWS Route 53 Records\n\n\nA & AAAA Record\n\n\nCNAME & Zone\n\tZone\n\tRecord(s)\n\tHas AAAA Record?\n\tComments\n\t.stacklok.com\n\tstacklok.com\n\tx.x.x.x\n\n\n\t\n\n\tThis is an IP address provided by Fixel, which does the web design and hosting for stacklok.com\n\tupdates.codegate.ai\n\tcodegate.ai\n\tEnvoy Production NLB\n\t\n\t\n\n\tinsight.stacklok.com\n\tstacklok.com\n\tx.x.x.x\n\n\n\t\n\n\tPoints to a Vercel IP where they hosts websites from.\n\t.codegate.ai\n\tcodegate.ai\n\tx.x.x.x\n\n\n\t\n\n\tThis is an IP address provided by Fixel, which does the web design and hosting for stacklok.com\n\twww.codegate.ai\n\tcodegate.ai\n\tx.x.x.x\n\n\n\t\n\n\tThis is an IP address provided by Fixel, which does the web design and hosting for stacklok.com\n\n\nCould be a CNAME instead\nCNAME Records\n\n\nCNAME & Zone\n\tZone\n\tRecord(s)\n\tComments\n\tstackers.stacklok.com\n\tstacklok.com\n\tghs.googlehosted.com.\n\n\n\tghs.googlehosted.com is a vanity URL. The direction to the stackers intranet is done based on the Host HTTP header.\nThere is configuration in Google Sites for route direction.\n\temail.gh-mail.stacklok.com\n\tstacklok.com\n\tmailgun.org.\n\n\n\tGreenHouse uses MailGun to send email\n\n\n\ths1-42544743._domainkey.stacklok.com\n\tstacklok.com\n\tstacklok-com.hs02a.dkim.hubspotemail.net.\n\n\n\t$keyname._domainkey is the format used for looking up DKIM public keys.  This particular one is for HubSpot, which is an email marketing platform.\n\n\nTo set up DKIM in HubSpot, you'll be guided to set up DKIM using two CNAME records in your DNS provider. Once you configure your DKIM records in your DNS provider using a public key that HubSpot provides you with, a receiving mail server (e.g. Gmail) will be able to verify the signature of your sent email that's associated with your domain.\n\n\nReference: https://knowledge.hubspot.com/marketing-email/manage-email-authentication-in-hubspot\n\n\n\ths2-42544743._domainkey.stacklok.com\n\tstacklok.com\n\tstacklok-com.hs02b.dkim.hubspotemail.net.\n\t$keyname._domainkey is the format used for looking up DKIM public keys.  This particular one is for HubSpot, which is an email marketing platform\n\twww.stacklok.com\n\tstacklok.com\n\tstacklok.com.\n\tLinks the \"www.\" subdomain of a domain to the stacklok.com root domain\n\tdocs.stacklok.com\n\tstacklok.com\n\tstacklok.github.io\n\tDocs github repository has custom domain routing setup in the Github Pages settings.\n\twww.insight.stacklok.com\n\tstacklok.com\n\tcname.vercel-dns.com.\n\tThis is the old Trusty website domain. Points to stacklok.com now\n\tdocs.codegate.ai\n\tcodegate.ai\n\tcname.vercel-dns.com.\nThe reason why we are using a CNAME here is because if you're using a Subdomain (e.g. docs.example.com), you will need to configure it with a CNAME record.\n\n\nhttps://vercel.com/docs/domains/working-with-dns",
    "updated_at": "2025-07-22T12:39:50Z",
    "link": "https://docs.google.com/document/d/1QH9j_SKuikXiBY21chzGvNLE6lD9o4OzdpFxZcN00WE/edit?tab=t.0#heading=h.zcrh246ywze9",
    "metadata": {
      "owner_names": ""
    }
  }, ...
]
```

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
