### PR TITLE
Onyx is not indexing some discord docs

### DIFF
--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -118,6 +118,7 @@ async def _fetch_documents_from_channel(
         start_time = discord_epoch
 
     async for channel_message in channel.history(
+        limit=None,
         after=start_time,
         before=end_time,
     ):
@@ -136,6 +137,7 @@ async def _fetch_documents_from_channel(
 
     for active_thread in channel.threads:
         async for thread_message in active_thread.history(
+            limit=None,
             after=start_time,
             before=end_time,
         ):
@@ -152,8 +154,11 @@ async def _fetch_documents_from_channel(
 
             yield _convert_message_to_document(thread_message, sections)
 
-    async for archived_thread in channel.archived_threads():
+    async for archived_thread in channel.archived_threads(
+        limit=None
+        ):
         async for thread_message in archived_thread.history(
+            limit=None,
             after=start_time,
             before=end_time,
         ):


### PR DESCRIPTION

Closes https://github.com/StacklokLabs/research/issues/54.

The code is not specifying a limit in most of the calls
The default limit is 1000 for archived and 100 for history. We set these to no limit (None) here. Tested locally (see ticket)

```
if __name__ == "__main__":
    import os
    import time

    end = time.time()
    # 1 day
    start = end - 3* 365 * 24 * 60 * 60 * 1

...
    count = 0
    funky_count = 0
    for doc_batch in connector.poll_source(start, end):
        for doc in doc_batch:
            count += 1
            print(doc)
            if 'funkymonkeymonk' in doc.semantic_identifier.lower():
                funky_count += 1
                print("Found funkymonkeymonk!")
    print(f"Total documents processed: {count}")
    print(f"Total funky documents found: {funky_count}")
```

Before change limit
```
Total documents processed: 707
Total funky documents found: 0
```
Roughly like
```
select count(id) from document
where id like('DISCORD_%') count|
-----+
  702|
```

With limit None
```
Total documents processed: 1169
Total funky documents found: 3
```
Which is the same number of funkymonkeymonk docs I find in the UI.

It seems we need to specify limit=None in several places like the diff.