### PR TITLE
chore: add needs-triage caller workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,13 @@
+name: Needs Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    uses: stacklok/.github/.github/workflows/needs-triage.yml@b43e3f174f9bbf2ca4efe6e421a1d007e7fa1b8f  # v1
+


### PR DESCRIPTION
Wires up the org-wide `needs-triage` reusable workflow.

**What it does:** any new or reopened issue is automatically labeled `needs-triage`. Removing the label is the explicit signal that a maintainer has triaged it. Bot-authored issues are skipped.

**Triage queue:** `is:issue is:open label:needs-triage`

Calls `stacklok/.github/.github/workflows/needs-triage.yml@v1` — `issues: write` only, action pinned to a commit SHA.